### PR TITLE
Fix compilation with OTP23

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,7 @@
 {erl_opts, [debug_info]}.
 {deps, []}.
 
-{port_env, [{".*", "CFLAGS", "$CFLAGS -Wall -O2"}]}.
+{port_env, [{".*", "CFLAGS", "$CFLAGS -Wall -O2"}, {"ERL_LDFLAGS", " -L$ERL_EI_LIBDIR -lei"}]}.
 {port_specs, [{"priv/b64fast.so", ["c_src/*.c"]}]}.
 
 {plugins, [pc]}.


### PR DESCRIPTION
Fixes this compile/link failure:

```
$ rebar compile
WARN:  Missing plugins: [pc]
==> b64fast (compile)
Compiled src/b64fast.erl
Compiling c_src/b64fast.c
ld: library not found for -lerl_interface
clang: error: linker command failed with exit code 1 (use -v to see invocation)
ERROR: sh(cc c_src/b64fast.o $LDFLAGS -bundle -flat_namespace -undefined suppress  -L"/usr/local/Cellar/erlang/23.0.3/lib/erlang/lib/erl_interface-4.0/lib" -lerl_interface -lei -o priv/b64fast.so)
failed with return code 1 and the following output:
ld: library not found for -lerl_interface
clang: error: linker command failed with exit code 1 (use -v to see invocation)

ERROR: compile failed while processing /Users/stu/dev/b64fast: rebar_abort
```